### PR TITLE
[dep] fixes #5: Upgrade datasets requirement to >=4.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ classifiers = [
 dependencies = [
     "accelerate",
     "codetiming",
-    "datasets",
+    "datasets>=4.0.0",
     "dill",
     "hydra-core",
     "numpy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 accelerate
 codetiming
-datasets
+datasets>=4.0.0
 dill
 hydra-core
 numpy


### PR DESCRIPTION
This commit bumps the minimum required version for the `datasets` library to 4.0.0.

Users on older versions of `datasets` were encountering a `Feature type 'List' not found` error. This issue arises because the 'List' feature type is not recognized in those legacy versions. Upgrading the dependency ensures compatibility and resolves this runtime error.

This change will provide a smoother setup experience for all users and align the project with the modern `datasets` API.

Closes #5