### PR TITLE
[core] feat: support vllm 0.10.0 and the lastest transformers

### DIFF
--- a/docker/Dockerfile.cu126
+++ b/docker/Dockerfile.cu126
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM nvcr.io/nvidia/cuda:12.4.1-cudnn-devel-ubuntu22.04
+FROM nvcr.io/nvidia/cuda:12.6.3-cudnn-devel-ubuntu22.04
 
 LABEL maintainer="SII AI Infra Team"
 
 # base environment
 RUN apt update \
-    && apt install -y rdma-core ibverbs-providers ibverbs-utils   \
+    && apt install -y rdma-core ibverbs-providers ibverbs-utils libnuma-dev  \
     && apt install -y python3 python3-pip \
     && ln -sf /usr/bin/python3 /usr/bin/python  \
     && python -m pip install -U pip \
@@ -28,13 +28,10 @@ RUN apt update \
 RUN apt install -y git cmake ninja-build vim
 
 # python packages
-RUN pip install torch==2.6.0 torchvision==0.21.0 torchaudio==2.6.0 --index-url https://download.pytorch.org/whl/cu124   \
-    && pip install flashinfer-python -i https://flashinfer.ai/whl/cu124/torch2.6/   \
-    && pip install flash-attn==2.7.3 --no-build-isolation   \
-    && pip install vllm==0.8.5.post1    \
-    && pip install accelerate codetiming datasets dill hydra-core pandas wandb loguru tensorboard qwen_vl_utils \
-    && pip install 'ray[default]>=2.47.1' \
-    && pip install opentelemetry-exporter-prometheus==0.47b0
+RUN pip install torch==2.7.1 torchvision==0.22.1 torchaudio==2.7.1   \
+    && pip install flash-attn==2.8.2 --no-build-isolation   \
+    && pip install vllm==0.10.0    \
+    && pip install accelerate codetiming datasets dill hydra-core pandas wandb loguru tensorboard qwen_vl_utils
 
 # apex
 RUN git clone https://github.com/NVIDIA/apex.git \
@@ -43,5 +40,5 @@ RUN git clone https://github.com/NVIDIA/apex.git \
     && cd .. && rm -rf apex
 
 # optional: sglang
-RUN pip install 'sglang[all]==0.4.6.post5'    \
-    && pip install xgrammar==0.1.18
+RUN pip install 'sglang[all]==0.4.10.post2' \
+    && pip install outlines==1.2.3 xgrammar==0.1.21

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,9 +84,9 @@ dependencies = [
     "qwen_vl_utils",
     "scipy",
     "fastapi",
-    "transformers<=4.51.3",
+    "transformers",
     "math-verify",
-    "vllm==0.8.5.post1",
+    "vllm>=0.8.5.post1",
 ]
 
 
@@ -114,9 +114,9 @@ geo = ["mathruler"]
 gpu = ["liger-kernel", "flash-attn"]
 sglang = [
     "tensordict>=0.8.0,<=0.9.1,!=0.9.0",
-    "sglang[all]==0.4.6.post5",
+    "sglang[all]>=0.4.6.post5",
     "torch-memory-saver>=0.0.5",
-    "torch==2.6.0",
+    "torch>=2.6.0",
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,4 @@ dacite
 qwen_vl_utils
 scipy
 fastapi
-transformers<=4.51.3
-math-verify
-vllm==0.8.5.post1
+vllm>=0.8.5.post1

--- a/siirl/models/transformers/qwen2_vl.py
+++ b/siirl/models/transformers/qwen2_vl.py
@@ -32,12 +32,23 @@ from siirl.utils.model_utils.ulysses import (
     validate_ulysses_config,
 )
 
+from siirl.models.transformers.monkey_patch import is_transformers_version_in_range
+
+# Handle version compatibility for flash_attn_supports_top_left_mask
+from siirl.models.transformers.transformers_compat import flash_attn_supports_top_left_mask
+
 try:
     from transformers.modeling_flash_attention_utils import flash_attn_func, flash_attn_varlen_func
 
     _flash_supports_window_size = "window_size" in list(inspect.signature(flash_attn_func).parameters)
 except ImportError:
-    flash_attn_varlen_func = None
+    try:
+        from transformers.modeling_flash_attention_utils import _lazy_imports
+        flash_attn_func, flash_attn_varlen_func, *_ = _lazy_imports(None)
+    except ImportError or ValueError:
+        from flash_attn import flash_attn_func, flash_attn_varlen_func
+
+    _flash_supports_window_size = None
 
 
 def get_rope_index(
@@ -211,7 +222,7 @@ def flash_attention_forward(
             query_length,
             is_causal=is_causal,
             sliding_window=sliding_window,
-            use_top_left_mask=use_top_left_mask,
+            use_top_left_mask=flash_attn_supports_top_left_mask(),
             deterministic=deterministic,
             **kwargs,
         )  # do not pass position_ids to old flash_attention_forward
@@ -281,7 +292,7 @@ def ulysses_flash_attn_forward(
         dropout=dropout_rate,
         sliding_window=sliding_window,
         is_causal=self.is_causal,
-        use_top_left_mask=self._flash_attn_uses_top_left_mask,
+        use_top_left_mask=flash_attn_supports_top_left_mask(),
         position_ids=position_ids,  # important: pass position ids
     )  # (batch_size, seq_length, num_head / sp_size, head_size)
     if ulysses_sp_size > 1:
@@ -289,7 +300,10 @@ def ulysses_flash_attn_forward(
 
     attn_output = attn_output.reshape(bsz, q_len, self.hidden_size).contiguous()
     attn_output = self.o_proj(attn_output)
-    return attn_output, None, None
+    if is_transformers_version_in_range(min_version="4.53.0"):
+        return attn_output, None
+    else:
+        return attn_output, None, None
 
 
 @dataclass

--- a/siirl/models/transformers/transformers_compat.py
+++ b/siirl/models/transformers/transformers_compat.py
@@ -1,0 +1,30 @@
+# Copyright 2024 Bytedance Ltd. and/or its affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Compatibility utilities for different versions of transformers library.
+"""
+
+# Handle version compatibility for flash_attn_supports_top_left_mask
+# This function was added in newer versions of transformers
+try:
+    from transformers.modeling_flash_attention_utils import flash_attn_supports_top_left_mask
+except ImportError:
+    # For older versions of transformers that don't have this function
+    # Default to False as a safe fallback for older versions
+    def flash_attn_supports_top_left_mask():
+        """Fallback implementation for older transformers versions.
+        Returns False to disable features that require this function.
+        """
+        return False


### PR DESCRIPTION
## **Overview**  

This PR updates the environment and codebase to support vllm==0.10.0 and the latest version of the transformers library.

## Key Changes:

1. **Dependency Updates**:

 - Upgraded vllm to >= 0.8.5.post1 in pyproject.toml and requirements.txt.

 - Removed the version pin for the transformers library in pyproject.toml and requirements.txt to allow for the latest version.

 - Updated sglang[all] to >= 0.4.6.post5 in  pyproject.toml and requirements.txt.

 - Removed the local installation of siiRL from the Dockerfile.

 - Add a Dockerfile with CUDA 12.6, including built-in PyTorch 2.7.1, vLLM 0.10.0, and SGLang 0.4.10.post2 libraries.

2. **Compatibility Fixes for Transformers**:

 - Introduced version checking (is_transformers_version_in_range) to handle conditional imports and function calls based on the transformers library version. This ensures backward compatibility while supporting newer versions.

 - Added a new compatibility utility file siiRL/models/transformers/transformers_compat.py to manage functions that vary across different transformers versions, such as flash_attn_supports_top_left_mask.

 - Refactored the `monkey_patch` function to dynamically import modules and apply patches depending on the installed transformers version, specifically for models like Qwen2_vL.

3. **Code Refinements**:

 - Replaced print statements with logger.info for better logging practices within the monkey patching logic.

 - Improved import handling by using try-except blocks to gracefully manage optional dependencies like flash_attn_func.

These changes ensure that the project remains compatible with the latest advancements in key dependencies like vllm and transformers, while maintaining stability and backward compatibility.
