### PR TITLE
[log] feat: remove log level settings to use env for control

### DIFF
--- a/siirl/utils/logger/logging_utils.py
+++ b/siirl/utils/logger/logging_utils.py
@@ -43,7 +43,6 @@ def set_basic_config():
         ),
         enqueue=True,
         colorize=True,
-        level="INFO",
     )
     os.makedirs(SIIRL_LOG_DIRCTORY, exist_ok=True)
 
@@ -54,6 +53,5 @@ def set_basic_config():
         format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level} | {module}:{function}:{line} >> {message}",
         compression="zip",
         encoding="utf-8",
-        level="DEBUG",
         enqueue=True,
     )


### PR DESCRIPTION
### Overview​​

This PR removes hardcoded log level configurations (INFO and DEBUG) from the `set_basic_config()` function in `logging_utils.py`. The log level is now controlled exclusively via the `LOGURU_LEVEL` environment variable. #22 

### ​Changes

- Deleted the `level="INFO"` setting for the console sink
- Deleted the `level="DEBUG"` setting for the file sink

### Note

While this change provides centralized control over logging levels through environment variables, it introduces a limitation: the `LOGURU_LEVEL` environment variable currently applies the same log level to both console and file sinks simultaneously. Separate control for terminal and file sinks is not yet supported.

