### PR TITLE
Bug fix on context parallel

### DIFF
--- a/siirl/engine/actor/megatron_actor.py
+++ b/siirl/engine/actor/megatron_actor.py
@@ -329,6 +329,19 @@ class MegatronPPOActor(BasePPOActor):
             src=mpu.get_pipeline_model_parallel_last_rank(),
             group=mpu.get_pipeline_model_parallel_group(),
         )
+        
+        # broadcast from cp rank 0 to all other cp ranks to ensure same data across CP group
+        cp_size = mpu.get_context_parallel_world_size()
+        if cp_size > 1:
+            # Get the first rank in this CP group (cp_rank=0)
+            cp_group = mpu.get_context_parallel_group()
+            cp_group_ranks = torch.distributed.get_process_group_ranks(cp_group)
+            src_rank = cp_group_ranks[0]  # cp_rank=0 in this group
+            broadcast_dict_tensor(
+                mini_batch,
+                src=src_rank,
+                group=cp_group,
+            )
         mini_batch.to("cpu")
         # split into micro-batches
         mini_batch["attention_mask"] = mini_batch["attention_mask"].to(bool)

--- a/siirl/engine/reward_model/megatron/reward_model.py
+++ b/siirl/engine/reward_model/megatron/reward_model.py
@@ -211,6 +211,18 @@ class MegatronRewardModel(BasePPORewardModel):
         mini_batch = data
         mini_batch.batch = mini_batch.batch.contiguous()
         broadcast_dict_tensor(mini_batch.batch, src=mpu.get_pipeline_model_parallel_last_rank(), group=mpu.get_pipeline_model_parallel_group())
+        
+        # broadcast from cp rank 0 to all other cp ranks to ensure same data across CP group
+        cp_size = mpu.get_context_parallel_world_size()
+        if cp_size > 1:
+            cp_group = mpu.get_context_parallel_group()
+            cp_group_ranks = torch.distributed.get_process_group_ranks(cp_group)
+            src_rank = cp_group_ranks[0]  # cp_rank=0 in this group
+            broadcast_dict_tensor(
+                mini_batch.batch,
+                src=src_rank,
+                group=cp_group,
+            )
 
         mini_batch.batch["attention_mask"] = mini_batch.batch["attention_mask"].to(bool)
 


### PR DESCRIPTION
Bug fix on CP: `forward_backward_batch` only broadcasts data within the PP (Pipeline Parallel) group, but not within the CP group, causing inconsistent packed sequence lengths